### PR TITLE
Feature/scale integration: Add Sartorius Cubis II scale integration and fix RPM/torque readings

### DIFF
--- a/docs/scale-integration-guide.md
+++ b/docs/scale-integration-guide.md
@@ -1,0 +1,196 @@
+# Sartorius Cubis II Scale - Integration Guide
+
+## Overview
+
+The HMI application reads weight data from a **Sartorius Cubis II MCA5201S-2S00-0** precision scale connected to the Raspberry Pi via USB. The weight is displayed in real-time on the HMI touchscreen and recorded alongside motor data (RPM, torque, etc.) in the Excel data export.
+
+### Scale Specifications
+
+| Specification | Value |
+|---------------|-------|
+| Model | Sartorius Cubis II MCA5201S-2S00-0 |
+| Capacity | 5200 g |
+| Readability | 0.1 g |
+| Interface | USB-B (Virtual COM port) |
+| Protocol | SBI (Sartorius Balance Interface) |
+
+---
+
+## Hardware Setup
+
+### USB Connection
+
+1. Connect the scale to the Raspberry Pi using a USB-B cable to any available USB port
+2. The scale appears as a virtual serial port at `/dev/ttyACM0`
+3. No additional drivers are required — the Linux `cdc_acm` kernel driver handles it automatically
+
+### Verifying the Connection
+
+After plugging in the USB cable, verify the scale is detected:
+
+```bash
+# Check that the device appears
+ls /dev/ttyACM*
+
+# Verify it's the Sartorius scale
+python -c "import serial.tools.list_ports; [print(f'{p.device} - {p.description}') for p in serial.tools.list_ports.comports()]"
+# Expected: /dev/ttyACM0 - Cubis MCA5201S-2S00-0 - CDC
+```
+
+### User Permissions
+
+The Pi user must be in the `dialout` group to access the serial port:
+
+```bash
+sudo usermod -a -G dialout $USER
+```
+
+Log out and back in for the change to take effect.
+
+---
+
+## Communication Protocol
+
+The scale uses the **SBI (Sartorius Balance Interface)** protocol over a USB virtual COM port. SBI is an ASCII-based command/response protocol used across Sartorius balance product lines.
+
+### Serial Parameters
+
+| Parameter | Value |
+|-----------|-------|
+| Baud rate | **19200** |
+| Data bits | **8** |
+| Parity | **None** |
+| Stop bits | **1** |
+| Timeout | 5 seconds |
+
+> **Note:** These parameters were verified on 2026-03-28 with the MCA5201S-2S00-0 unit connected to this system. The Sartorius factory defaults can vary between units (some ship at 9600 baud with 7-O-1). If replacing the scale or after a factory reset, the parameters may need to be re-verified using `tests/test_scale_connection.py`.
+
+### Command Used
+
+| Command | Bytes | Description |
+|---------|-------|-------------|
+| ESC P | `\x1bP\r\n` | Request stable weight reading |
+
+The application sends `ESC P` (print/stable read). This command waits until the scale reading is stable before responding, which typically takes 1-3 seconds.
+
+> **Note:** `ESC S` (immediate/unstable read) was tested and is **not supported** on this unit. Only `ESC P` produces a response.
+
+### Response Format
+
+The scale responds with a **22-byte fixed-width ASCII string**:
+
+```
+G     +    256.1 g  \r\n
+│     │    │     │
+│     │    │     └── Unit (present = stable, absent = unstable)
+│     │    └──────── Weight value (right-justified, space-padded)
+│     └───────────── Sign (+ or -)
+└─────────────────── Status (G = Gross, N = Net)
+```
+
+**Stable vs Unstable responses:**
+
+The scale omits the unit when the reading is unstable (weight is still settling). Once the reading stabilizes, the unit (`g`) appears in the response.
+
+| Raw Response | Weight | Stable? | Meaning |
+|-------------|--------|---------|---------|
+| `G            0.0 g  \r\n` | 0.0 | Yes | Empty scale (no sign for zero) |
+| `G     +    256.1 g  \r\n` | 256.1 | Yes | Stable reading with object |
+| `G     +    381.6    \r\n` | 381.6 | No | Weight is changing/settling |
+| `G     +    619.5 g  \r\n` | 619.5 | Yes | Stable after adding weight |
+
+**Status characters:**
+- `G` = Gross weight (no tare applied)
+- `N` = Net weight (tare applied)
+
+**Stability behavior with ESC P:**
+- ESC P requests a stable reading, but when weight is actively changing, it still returns an unstable response (without unit) rather than blocking indefinitely
+- During transitions (adding/removing weight), expect 2-5 unstable readings before the value settles
+- The application uses both stable and unstable readings for display, since the numeric value is still valid
+
+### Other SBI Commands (Reference)
+
+These commands are available in the SBI protocol but are not currently used by the application:
+
+| Command | Bytes | Description |
+|---------|-------|-------------|
+| ESC T | `\x1bT\r\n` | Tare the scale |
+| ESC Z | `\x1bZ\r\n` | Zero the scale |
+| ESC S | `\x1bS\r\n` | Immediate read (not supported on this unit) |
+
+---
+
+## Scale Settings on the Cubis II Touchscreen
+
+If the scale stops communicating (e.g., after a factory reset), verify these settings on the scale's built-in touchscreen:
+
+1. Navigate to **Menu** > **Communication** > **USB**
+2. Verify:
+   - **Protocol**: SBI
+   - **Baud rate**: 19200
+   - **Data bits**: 8
+   - **Parity**: None
+   - **Stop bits**: 1
+   - **Handshake**: None
+
+---
+
+## How It Works in the Application
+
+### Architecture
+
+```
+┌──────────────┐      USB Serial       ┌──────────────────┐
+│   Sartorius  │  ──────────────────>   │   Raspberry Pi   │
+│   Cubis II   │  /dev/ttyACM0         │                  │
+│   Scale      │  19200 baud, 8-N-1    │  Scale class     │
+└──────────────┘                        │  (background     │
+                                        │   thread polls   │
+                                        │   every ~3-5s)   │
+                                        │       │          │
+                                        │       v          │
+                                        │  Cached weight   │
+                                        │       │          │
+                                        │       v          │
+                                        │  HMI UI + Excel  │
+                                        └──────────────────┘
+```
+
+### Data Flow
+
+1. A **background daemon thread** in the `Scale` class continuously sends `ESC P` and reads the response
+2. Each response is parsed to extract the numeric weight value and unit
+3. The parsed weight is cached as a float — the UI thread reads this cached value every 1 second via `get_weight()`
+4. The weight is:
+   - **Displayed** on the HMI touchscreen in the right panel
+   - **Recorded** every second while the motor is running, into the data dictionary
+   - **Exported** as a column in the Excel file when the motor is stopped
+
+### Error Handling
+
+- If the scale is **disconnected**, the application continues running normally — weight displays as `0.0`
+- If the scale is **reconnected**, the background thread automatically re-establishes communication within a few seconds
+- All serial communication errors are caught silently to prevent UI crashes (consistent with the motor sensor pattern)
+
+---
+
+## Troubleshooting
+
+| Symptom | Likely Cause | Solution |
+|---------|-------------|----------|
+| Scale not detected (`/dev/ttyACM0` missing) | USB cable disconnected or faulty | Check USB cable, try a different USB port |
+| Permission denied on `/dev/ttyACM0` | User not in `dialout` group | Run `sudo usermod -a -G dialout $USER`, then log out/in |
+| No response from scale | Protocol settings mismatch | Check scale touchscreen: Menu > Communication > USB > Protocol = SBI |
+| Weight always shows 0.0 | Scale not connected or communication error | Run `python tests/test_scale_connection.py` to diagnose |
+| Garbled response data | Baud rate or parity mismatch | Verify serial parameters match between scale settings and application config |
+
+### Running the Diagnostic Test
+
+A standalone test script is included to verify scale communication independently from the HMI application:
+
+```bash
+cd ~/HMI-Motor-Controller
+python tests/test_scale_connection.py
+```
+
+This script will confirm the serial port, parameters, and response format.

--- a/hmi/HMIApp.py
+++ b/hmi/HMIApp.py
@@ -97,7 +97,7 @@ class Main(Screen):
 
         self.toggle_motor_drive_fault = False
         self.toggle_e_stop_active = False
-        self.rpms = [0,0,0]
+        self.rpms = [0] * 5
         self.rpm_average = 0
         self.motor_drive_fault_lock = False
         self.e_stop_active_lock = False
@@ -293,7 +293,7 @@ class Main(Screen):
 
         self.rpms.insert(0, self.get_rpm())
         self.rpms.pop()
-        self.rpm_average = int(sum(self.rpms)/len(self.rpms))
+        self.rpm_average = int(sorted(self.rpms)[len(self.rpms) // 2])  # median filter
 
         if self.is_jogging and not self.is_system_running():
         # if self.is_jogging:

--- a/hmi/HMIApp.py
+++ b/hmi/HMIApp.py
@@ -204,7 +204,6 @@ class Main(Screen):
             self.current_rpm_str = "0.0"
             self.blade_tip_velocity_str = "0.0"
             self.total_revolution_str = "0.0"
-            self.weight_str = "0.0"
             # if self.rpm_input == 0:
             #     self.is_rpm_input_valid = False
             self.seconds_counter = 0
@@ -305,6 +304,7 @@ class Main(Screen):
 
         torque_data = self.stepper_motor.get_torque()   # get the torque data from the torque sensor
         # self.torque_sensor_str = str(torque_data)
+        self.weight_str = str(self.scale.get_weight())  # update weight display (always, not just when running)
         self.now = datetime.today() # get the current time
         is_motor_fault_active = self.stepper_motor.is_drive_fault_active()
         is_e_stop_active = self.stepper_motor.is_e_stop_active()
@@ -355,7 +355,6 @@ class Main(Screen):
             self.data['Torque'].append(torque_data)
             self.data['Blade Tip Velocity'].append(self.blade_tip_velocity_str)   # TO DO: get the blade tip velocity from the stepper motor
             self.data['Total Revolution'].append(self.total_revolution_str)
-            self.weight_str = str(self.scale.get_weight())
             self.data['Weight'].append(self.weight_str)
 
             # # update the RPM and blade tip velocity

--- a/hmi/HMIApp.py
+++ b/hmi/HMIApp.py
@@ -24,6 +24,7 @@ from datetime import date, datetime, timedelta
 from timeit import default_timer as timer
 from HMIConfig import HMI_Config
 from sensors.stepper_motor import Stepper_Motor
+from sensors.scale import Scale
 import time
 import excel
 import re
@@ -49,6 +50,7 @@ class Main(Screen):
     blade_tip_velocity_str  = StringProperty('')
     total_revolution_str    = StringProperty('')
     current_rpm_str         = StringProperty('')
+    weight_str              = StringProperty('0.0')
     motor_drive_fault_str   = StringProperty('')
     e_stop_active_str       = StringProperty('')
     run_button_color        = ListProperty([1, 1, 1, 1])
@@ -74,6 +76,7 @@ class Main(Screen):
         self.past_time = 0
         self.excel              = excel # create an instance of the excel module to save the data
         self.stepper_motor      = Stepper_Motor() # create an instance of the stepper motor
+        self.scale              = Scale()          # create an instance of the scale sensor
         Clock.schedule_interval(self.update_callback, 1)    # setup periodic task
         Clock.schedule_interval(self.update_callback_date, 300)    # setup periodic task
         self.counter = 0
@@ -169,7 +172,8 @@ class Main(Screen):
             'Torque': [],
             'Blade Tip Velocity': [],
             'Total Revolution': [],
-            'Notes': []
+            'Notes': [],
+            'Weight': []
         }
         return self.data
 
@@ -200,6 +204,7 @@ class Main(Screen):
             self.current_rpm_str = "0.0"
             self.blade_tip_velocity_str = "0.0"
             self.total_revolution_str = "0.0"
+            self.weight_str = "0.0"
             # if self.rpm_input == 0:
             #     self.is_rpm_input_valid = False
             self.seconds_counter = 0
@@ -350,6 +355,8 @@ class Main(Screen):
             self.data['Torque'].append(torque_data)
             self.data['Blade Tip Velocity'].append(self.blade_tip_velocity_str)   # TO DO: get the blade tip velocity from the stepper motor
             self.data['Total Revolution'].append(self.total_revolution_str)
+            self.weight_str = str(self.scale.get_weight())
+            self.data['Weight'].append(self.weight_str)
 
             # # update the RPM and blade tip velocity
             if self.is_rpm_input_valid and not self.is_jogging:

--- a/hmi/excel.py
+++ b/hmi/excel.py
@@ -29,6 +29,7 @@ def save_data(data, filename):
     worksheet.set_column('G:G', 20)
     worksheet.set_column('H:H', 20)
     worksheet.set_column('I:I', 20)
+    worksheet.set_column('J:J', 20)
 
     # Add a bold format to use to highlight cells.
     header_format = workbook.add_format({'bold': True, 'text_wrap': True, 'align': 'center', 'valign': 'vcenter'})
@@ -46,6 +47,7 @@ def save_data(data, filename):
     worksheet.write('G1', 'Blade Tip Velocity', header_format)
     worksheet.write('H1', 'Total Revolution', header_format)
     worksheet.write('I1', 'Notes', header_format)
+    worksheet.write('J1', 'Weight', header_format)
 
     # write data dictionary into excel 
     row = 1

--- a/hmi/hmi.kv
+++ b/hmi/hmi.kv
@@ -170,16 +170,16 @@ WindowManager:
                 font_size: 40
                 on_focus: self.text = "" if self.focus else "{}".format(self.text)
                 on_text_validate: root.on_notes_input(self.text)
-            # BoxLayout:
-            #     orientation: "horizontal"
-            #     Label:
-            #         text: "[b]TORQUE (Nm)[/b]"
-            #         font_size: 30
-            #         markup: True
-            #     Label:
-            #         text: "[b]{}[/b]".format(root.torque_sensor_str)
-            #         font_size: 50
-            #         markup: True
+            BoxLayout:
+                orientation: "horizontal"
+                Label:
+                    text: "[b]TORQUE (Nm)[/b]"
+                    font_size: 30
+                    markup: True
+                Label:
+                    text: "[b]{}[/b]".format(root.torque_sensor_str)
+                    font_size: 50
+                    markup: True
             BoxLayout:
                 orientation: "horizontal"
                 Label:

--- a/hmi/hmi.kv
+++ b/hmi/hmi.kv
@@ -228,3 +228,13 @@ WindowManager:
                     text: "[b]{}[/b]".format(root.current_rpm_str)
                     font_size: 50
                     markup: True
+            BoxLayout:
+                orientation: "horizontal"
+                Label:
+                    text: "[b]Weight (g)[/b]"
+                    font_size: 30
+                    markup: True
+                Label:
+                    text: "[b]{}[/b]".format(root.weight_str)
+                    font_size: 50
+                    markup: True

--- a/hmi/sensors/scale.py
+++ b/hmi/sensors/scale.py
@@ -1,0 +1,165 @@
+import serial
+import serial.tools.list_ports
+import threading
+import time
+import re
+
+
+class Scale:
+    """Sartorius Cubis II MCA5201S-2S00-0 SBI interface over USB serial.
+
+    Communicates using the SBI (Sartorius Balance Interface) protocol.
+    A background daemon thread polls the scale continuously and caches the
+    latest weight reading. Call get_weight() from the UI thread — it returns
+    the cached value instantly without blocking.
+
+    Verified config (2026-03-30):
+        Port: /dev/ttyACM0  |  19200 baud, 8-N-1  |  ESC P command
+    """
+
+    # SBI command — ESC P (stable read). ESC S is not supported on this unit.
+    _CMD_READ = b'\x1bP\r\n'
+
+    # Serial parameters (verified on MCA5201S-2S00-0)
+    _BAUD = 19200
+    _BYTESIZE = serial.EIGHTBITS
+    _PARITY = serial.PARITY_NONE
+    _STOPBITS = serial.STOPBITS_ONE
+    _TIMEOUT = 5.0  # ESC P blocks until stable, typically 1-3s
+
+    # Regex to extract numeric value from SBI response.
+    # Handles both stable ("G     +    256.1 g  ") and unstable ("G     +    381.6    ")
+    _WEIGHT_RE = re.compile(r'([+-]?\s*[\d.]+)')
+
+    _POLL_INTERVAL = 0.5        # seconds between poll attempts
+    _RECONNECT_INTERVAL = 2.0   # seconds between reconnect attempts
+
+    def __init__(self, port=None):
+        self._port_path = port
+        self._serial = None
+        self._weight = 0.0
+        self._unit = 'g'
+        self._stable = False
+        self._connected = False
+        self._lock = threading.Lock()
+
+        self._connect(port)
+
+        # Background polling thread (mirrors stepper_motor._ramp_thread pattern)
+        self._running = True
+        self._poll_thread = threading.Thread(target=self._poll_worker, daemon=True)
+        self._poll_thread.start()
+
+    def _find_port(self):
+        """Auto-detect Sartorius scale USB port."""
+        try:
+            ports = serial.tools.list_ports.comports()
+            for p in ports:
+                if 'Cubis' in (p.description or '') or 'Sartorius' in (p.description or ''):
+                    return p.device
+                if 'ttyACM' in p.device:
+                    return p.device
+        except Exception:
+            pass
+        return None
+
+    def _connect(self, port=None):
+        """Open serial connection to the scale."""
+        try:
+            if port is None:
+                port = self._find_port()
+            if port is None:
+                self._connected = False
+                return
+            self._serial = serial.Serial(
+                port=port,
+                baudrate=self._BAUD,
+                bytesize=self._BYTESIZE,
+                parity=self._PARITY,
+                stopbits=self._STOPBITS,
+                timeout=self._TIMEOUT
+            )
+            self._connected = True
+            self._port_path = port
+        except Exception:
+            self._connected = False
+
+    def _parse_response(self, raw):
+        """Parse SBI response bytes into weight float.
+
+        Stable response:   b'G     +    256.1 g  \\r\\n'  -> 256.1
+        Unstable response: b'G     +    381.6    \\r\\n'  -> 381.6
+        """
+        try:
+            text = raw.decode('ascii', errors='ignore').strip()
+            # Check for error responses
+            if text.startswith('E') or not text:
+                return None, False
+
+            # Detect stability: unit present means stable
+            stable = bool(re.search(r'[a-zA-Z]\s*$', text))
+
+            # Extract numeric value (skip the status character at position 0)
+            match = self._WEIGHT_RE.search(text[1:])
+            if match:
+                value_str = match.group(1).replace(' ', '')
+                return float(value_str), stable
+        except Exception:
+            pass
+        return None, False
+
+    def _poll_worker(self):
+        """Background thread: reads weight continuously, caches result."""
+        while self._running:
+            if not self._connected:
+                self._connect(self._port_path)
+                time.sleep(self._RECONNECT_INTERVAL)
+                continue
+            try:
+                with self._lock:
+                    self._serial.reset_input_buffer()
+                    self._serial.write(self._CMD_READ)
+                    response = self._serial.readline()
+                value, stable = self._parse_response(response)
+                if value is not None:
+                    self._weight = value
+                    self._stable = stable
+            except Exception:
+                self._connected = False
+                try:
+                    if self._serial and self._serial.is_open:
+                        self._serial.close()
+                except Exception:
+                    pass
+            time.sleep(self._POLL_INTERVAL)
+
+    def get_weight(self):
+        """Return latest weight reading in grams. Safe to call from UI thread."""
+        try:
+            return self._weight
+        except Exception:
+            return 0.0
+
+    def get_unit(self):
+        """Return unit string from last reading."""
+        try:
+            return self._unit
+        except Exception:
+            return 'g'
+
+    def is_stable(self):
+        """Return True if the last reading was a stable (settled) value."""
+        return self._stable
+
+    def is_connected(self):
+        """Return True if serial connection to scale is active."""
+        return self._connected
+
+    def close(self):
+        """Stop polling and close serial connection."""
+        self._running = False
+        try:
+            if self._serial and self._serial.is_open:
+                self._serial.close()
+        except Exception:
+            pass

--- a/hmi/sensors/stepper_motor.py
+++ b/hmi/sensors/stepper_motor.py
@@ -162,6 +162,10 @@ class Stepper_Motor:
     def get_rpm(self):
         freq = self.get_frequency()
         rpm = int((freq * 60.0)/1000)/10
+        # Clamp: reject readings more than 50% above target RPM (noise spikes)
+        target_rpm = (self._target_freq * 60.0) / self.__REVOLUTIONS
+        if target_rpm > 0 and rpm > target_rpm * 1.5:
+            return int(target_rpm)
         return rpm
 
     def ramp_to_rpm(self, rpm_input, ramp_time=1.0):

--- a/hmi/sensors/stepper_motor.py
+++ b/hmi/sensors/stepper_motor.py
@@ -95,7 +95,8 @@ class Stepper_Motor:
 
     def get_torque(self) -> float:
         try:
-            Nm = abs(round(DAQC2.getADC(self.addr, self.torque_addr) * 0.05, 4))
+            adc_value = DAQC2.getADC(self.addr, self.torque_addr)
+            Nm = round(max(0, (adc_value - 0.1)) * 0.05, 4)
             return Nm
         except:
             print("Error: Torque sensor not connected")

--- a/requirements.txt
+++ b/requirements.txt
@@ -18,3 +18,4 @@ spidev==3.5
 tendo==0.2.15
 urllib3==1.26.7
 XlsxWriter==3.0.2
+pyserial==3.5

--- a/tests/test_scale_class.py
+++ b/tests/test_scale_class.py
@@ -1,0 +1,68 @@
+"""
+Test script for the Scale sensor class.
+
+Run this on the Raspberry Pi with the scale connected via USB:
+    python tests/test_scale_class.py
+
+This tests the production Scale class (hmi/sensors/scale.py) by:
+1. Instantiating it and letting the background thread connect
+2. Printing get_weight(), is_connected(), is_stable() in a loop
+3. Monitoring for 60 seconds — place/remove objects to verify weight changes
+
+Prerequisites:
+    - pip install pyserial
+    - User must be in 'dialout' group
+"""
+
+import sys
+import os
+import time
+
+# Add hmi directory to path so we can import sensors.scale
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..', 'hmi'))
+
+from sensors.scale import Scale
+
+
+def main():
+    print("=" * 60)
+    print("Scale Class Test")
+    print("=" * 60)
+
+    print("\nInstantiating Scale (auto-detect port)...")
+    scale = Scale()
+
+    # Give the background thread a moment to connect and get first reading
+    time.sleep(2.0)
+
+    print(f"  Connected: {scale.is_connected()}")
+    if not scale.is_connected():
+        print("  WARNING: Scale not connected. Will keep trying (auto-reconnect)...")
+    print()
+
+    print("--- Live readings for 60 seconds ---")
+    print("  Place/remove objects on the scale to see changes.")
+    print("  Press Ctrl+C to stop early.\n")
+
+    try:
+        for i in range(60):
+            weight = scale.get_weight()
+            connected = scale.is_connected()
+            stable = scale.is_stable()
+            status = "STABLE" if stable else "UNSTABLE"
+            conn = "OK" if connected else "DISCONNECTED"
+
+            print(f"  [{i+1:3d}s]  {weight:>8.1f} g  |  {status:<10s}  |  {conn}")
+            time.sleep(1.0)
+    except KeyboardInterrupt:
+        print("\n  Stopped by user.")
+
+    print(f"\nFinal reading: {scale.get_weight()} {scale.get_unit()}")
+    print(f"Connected: {scale.is_connected()}")
+
+    scale.close()
+    print("\nScale closed. Done.")
+
+
+if __name__ == '__main__':
+    main()

--- a/tests/test_scale_connection.py
+++ b/tests/test_scale_connection.py
@@ -1,0 +1,185 @@
+"""
+Standalone test script for Sartorius Cubis II MCA5201S-2S00-0 scale communication.
+
+Run this on the Raspberry Pi with the scale connected via USB:
+    python tests/test_scale_connection.py
+
+Prerequisites:
+    - pip install pyserial
+    - User must be in 'dialout' group: sudo usermod -a -G dialout $USER
+    - Scale touchscreen: Menu > Communication > USB > Protocol = SBI
+"""
+
+import serial
+import serial.tools.list_ports
+import time
+import sys
+
+
+def list_serial_ports():
+    """List all available serial ports."""
+    ports = serial.tools.list_ports.comports()
+    if not ports:
+        print("No serial ports found.")
+        return []
+    print("Available serial ports:")
+    for p in ports:
+        print(f"  {p.device} - {p.description} [VID:PID={p.vid}:{p.pid}]")
+    return ports
+
+
+def try_read_weight(port, baudrate, bytesize, parity, stopbits):
+    """Attempt to read weight from the scale with given serial parameters."""
+    params_str = f"{baudrate} baud, {bytesize} data bits, parity={parity}, {stopbits} stop bits"
+    print(f"\nTrying: {port} @ {params_str}")
+
+    try:
+        ser = serial.Serial(
+            port=port,
+            baudrate=baudrate,
+            bytesize=bytesize,
+            parity=parity,
+            stopbits=stopbits,
+            timeout=2.0
+        )
+    except serial.SerialException as e:
+        print(f"  ERROR opening port: {e}")
+        return False
+
+    try:
+        # Flush any stale data
+        ser.reset_input_buffer()
+        time.sleep(0.1)
+
+        # Send SBI immediate read command (ESC S)
+        cmd = b'\x1bS\r\n'
+        print(f"  Sending: {cmd!r}")
+        ser.write(cmd)
+
+        # Read response
+        response_raw = ser.readline()
+        print(f"  Raw bytes:   {response_raw!r}")
+        print(f"  Decoded:     '{response_raw.decode('ascii', errors='replace').strip()}'")
+
+        if not response_raw:
+            print("  No response received (timeout).")
+            # Try stable read command as fallback
+            print("  Retrying with ESC P (stable read)...")
+            ser.write(b'\x1bP\r\n')
+            response_raw = ser.readline()
+            print(f"  Raw bytes:   {response_raw!r}")
+            print(f"  Decoded:     '{response_raw.decode('ascii', errors='replace').strip()}'")
+
+        if response_raw:
+            print("  SUCCESS - got a response!")
+            return True
+        else:
+            print("  No response.")
+            return False
+
+    except Exception as e:
+        print(f"  ERROR during communication: {e}")
+        return False
+    finally:
+        ser.close()
+
+
+def main():
+    print("=" * 60)
+    print("Sartorius Cubis II Scale - Communication Test")
+    print("=" * 60)
+
+    # Step 1: List ports
+    print("\n--- Step 1: Detecting serial ports ---")
+    ports = list_serial_ports()
+
+    # Find likely scale port (ttyACM or ttyUSB devices)
+    candidate_ports = []
+    for p in ports:
+        if 'ttyACM' in p.device or 'ttyUSB' in p.device:
+            candidate_ports.append(p.device)
+
+    if not candidate_ports:
+        # On Windows, look for COM ports
+        for p in ports:
+            if 'COM' in p.device:
+                candidate_ports.append(p.device)
+
+    if not candidate_ports:
+        print("\nNo candidate serial ports found.")
+        print("Check that the scale is connected via USB and powered on.")
+        sys.exit(1)
+
+    print(f"\nCandidate ports: {candidate_ports}")
+
+    # Step 2: Try each port with different serial configurations
+    print("\n--- Step 2: Testing communication ---")
+
+    configs = [
+        # Default SBI: 9600, 7-O-1
+        (9600, serial.SEVENBITS, serial.PARITY_ODD, serial.STOPBITS_ONE),
+        # Alternative: 19200, 7-O-1
+        (19200, serial.SEVENBITS, serial.PARITY_ODD, serial.STOPBITS_ONE),
+        # Alternative: 9600, 8-N-1
+        (9600, serial.EIGHTBITS, serial.PARITY_NONE, serial.STOPBITS_ONE),
+        # Alternative: 19200, 8-N-1
+        (19200, serial.EIGHTBITS, serial.PARITY_NONE, serial.STOPBITS_ONE),
+    ]
+
+    success = False
+    for port in candidate_ports:
+        for baudrate, bytesize, parity, stopbits in configs:
+            if try_read_weight(port, baudrate, bytesize, parity, stopbits):
+                success = True
+                print(f"\n{'=' * 60}")
+                print(f"WORKING CONFIG FOUND!")
+                print(f"  Port:      {port}")
+                print(f"  Baud rate: {baudrate}")
+                print(f"  Data bits: {bytesize}")
+                print(f"  Parity:    {parity}")
+                print(f"  Stop bits: {stopbits}")
+                print(f"{'=' * 60}")
+
+                # Do a few more reads to confirm
+                print("\nPerforming 5 consecutive reads (1 second apart)...")
+                try:
+                    ser = serial.Serial(
+                        port=port,
+                        baudrate=baudrate,
+                        bytesize=bytesize,
+                        parity=parity,
+                        stopbits=stopbits,
+                        timeout=2.0
+                    )
+                    for i in range(5):
+                        ser.reset_input_buffer()
+                        ser.write(b'\x1bS\r\n')
+                        resp = ser.readline()
+                        decoded = resp.decode('ascii', errors='replace').strip()
+                        print(f"  Read {i+1}: '{decoded}'")
+                        time.sleep(1.0)
+                    ser.close()
+                except Exception as e:
+                    print(f"  Error during consecutive reads: {e}")
+
+                return
+        if not success:
+            print(f"\nNo working config found for {port}")
+
+    if not success:
+        print("\n" + "=" * 60)
+        print("FAILED: Could not communicate with the scale.")
+        print("Troubleshooting:")
+        print("  1. Check scale is powered on and USB cable is connected")
+        print("  2. On the scale touchscreen: Menu > Communication > USB")
+        print("     - Protocol should be set to 'SBI'")
+        print("  3. Verify user is in dialout group:")
+        print("     sudo usermod -a -G dialout $USER")
+        print("     (then log out and back in)")
+        print("  4. Check dmesg for USB device detection:")
+        print("     dmesg | tail -20")
+        print("=" * 60)
+
+
+if __name__ == '__main__':
+    main()

--- a/tests/test_scale_connection.py
+++ b/tests/test_scale_connection.py
@@ -4,6 +4,12 @@ Standalone test script for Sartorius Cubis II MCA5201S-2S00-0 scale communicatio
 Run this on the Raspberry Pi with the scale connected via USB:
     python tests/test_scale_connection.py
 
+Confirmed working config:
+    Port: /dev/ttyACM0
+    Baud: 19200, 8-N-1
+    Command: ESC P (b'\\x1bP\\r\\n') - stable weight read
+    Response: 22-byte extended SBI, e.g. 'G            0.0 g  \\r\\n'
+
 Prerequisites:
     - pip install pyserial
     - User must be in 'dialout' group: sudo usermod -a -G dialout $USER
@@ -11,237 +17,122 @@ Prerequisites:
 
 import serial
 import serial.tools.list_ports
+import re
 import time
 import sys
+
+# Confirmed working parameters
+PORT = '/dev/ttyACM0'
+BAUD = 19200
+BYTESIZE = serial.EIGHTBITS
+PARITY = serial.PARITY_NONE
+STOPBITS = serial.STOPBITS_ONE
+TIMEOUT = 3.0
+
+# SBI commands
+CMD_STABLE_READ = b'\x1bP\r\n'
+CMD_IMMEDIATE_READ = b'\x1bS\r\n'
+
+# Regex to parse weight from response like 'G            0.0 g'
+WEIGHT_RE = re.compile(r'([+-]?\s*[\d.]+)\s+(\w+)')
 
 
 def list_serial_ports():
     """List all available serial ports."""
     ports = serial.tools.list_ports.comports()
-    if not ports:
-        print("No serial ports found.")
-        return []
     print("Available serial ports:")
     for p in ports:
         print(f"  {p.device} - {p.description} [VID:PID={p.vid}:{p.pid}]")
     return ports
 
 
-def open_port(port, baudrate=9600, bytesize=serial.EIGHTBITS,
-              parity=serial.PARITY_NONE, stopbits=serial.STOPBITS_ONE):
-    """Open serial port with given parameters."""
+def open_scale():
+    """Open serial connection to the scale."""
     return serial.Serial(
-        port=port,
-        baudrate=baudrate,
-        bytesize=bytesize,
-        parity=parity,
-        stopbits=stopbits,
-        timeout=3.0
+        port=PORT,
+        baudrate=BAUD,
+        bytesize=BYTESIZE,
+        parity=PARITY,
+        stopbits=STOPBITS,
+        timeout=TIMEOUT
     )
 
 
-def test_passive_listen(port):
-    """Test 1: Just listen for any data the scale sends without commands."""
-    print("\n--- Test 1: Passive listen (no commands sent) ---")
-    print("  Listening for 5 seconds for any data the scale sends...")
-
-    ser = open_port(port)
-    try:
-        ser.reset_input_buffer()
-        start = time.time()
-        data = b''
-        while time.time() - start < 5.0:
-            chunk = ser.read(ser.in_waiting or 1)
-            if chunk:
-                data += chunk
-                print(f"  Received: {chunk!r}")
-        if not data:
-            print("  No data received passively.")
-        else:
-            print(f"  Total received: {data!r}")
-            print(f"  Decoded: '{data.decode('ascii', errors='replace')}'")
-        return bool(data)
-    except Exception as e:
-        print(f"  ERROR: {e}")
-        return False
-    finally:
-        ser.close()
-
-
-def test_sbi_commands(port):
-    """Test 2: Try SBI commands with different formats."""
-    print("\n--- Test 2: SBI command variations ---")
-
-    commands = [
-        (b'\x1bS\r\n', "ESC S CR LF (standard SBI immediate)"),
-        (b'\x1bP\r\n', "ESC P CR LF (standard SBI print/stable)"),
-        (b'\x1bS\r',   "ESC S CR (no LF)"),
-        (b'\x1bP\r',   "ESC P CR (no LF)"),
-        (b'S\r\n',     "S CR LF (no ESC prefix)"),
-        (b'P\r\n',     "P CR LF (no ESC prefix)"),
-        (b'\x1bQ\r\n', "ESC Q CR LF (query)"),
-        (b'W\r\n',     "W CR LF (weigh command)"),
-        (b'\x1b\x70\r\n', "ESC p (lowercase) CR LF"),
-    ]
-
-    ser = open_port(port)
-    try:
-        for cmd, desc in commands:
-            ser.reset_input_buffer()
-            time.sleep(0.2)
-            print(f"\n  Sending {desc}: {cmd!r}")
-            ser.write(cmd)
-            time.sleep(0.5)
-
-            # Try readline first
-            response = ser.readline()
-            if not response:
-                # Also try reading raw bytes
-                response = ser.read(ser.in_waiting or 0)
-
-            if response:
-                print(f"  Raw bytes: {response!r}")
-                print(f"  Decoded:   '{response.decode('ascii', errors='replace').strip()}'")
-                print(f"  SUCCESS with: {desc}")
-                return True, cmd, desc
-            else:
-                print(f"  No response.")
-
-        return False, None, None
-    except Exception as e:
-        print(f"  ERROR: {e}")
-        return False, None, None
-    finally:
-        ser.close()
-
-
-def test_serial_configs(port):
-    """Test 3: Try different serial configurations with SBI commands."""
-    print("\n--- Test 3: Different serial configurations ---")
-
-    configs = [
-        (9600,  serial.EIGHTBITS, serial.PARITY_NONE, serial.STOPBITS_ONE, "9600 8-N-1"),
-        (9600,  serial.SEVENBITS, serial.PARITY_ODD,  serial.STOPBITS_ONE, "9600 7-O-1"),
-        (9600,  serial.SEVENBITS, serial.PARITY_EVEN, serial.STOPBITS_ONE, "9600 7-E-1"),
-        (19200, serial.EIGHTBITS, serial.PARITY_NONE, serial.STOPBITS_ONE, "19200 8-N-1"),
-        (19200, serial.SEVENBITS, serial.PARITY_ODD,  serial.STOPBITS_ONE, "19200 7-O-1"),
-        (115200, serial.EIGHTBITS, serial.PARITY_NONE, serial.STOPBITS_ONE, "115200 8-N-1"),
-    ]
-
-    commands = [b'\x1bS\r\n', b'\x1bP\r\n']
-
-    for baud, bits, parity, stop, desc in configs:
-        try:
-            ser = serial.Serial(
-                port=port, baudrate=baud, bytesize=bits,
-                parity=parity, stopbits=stop, timeout=2.0
-            )
-        except serial.SerialException as e:
-            print(f"\n  {desc}: ERROR opening - {e}")
-            continue
-
-        try:
-            for cmd in commands:
-                ser.reset_input_buffer()
-                time.sleep(0.1)
-                ser.write(cmd)
-                time.sleep(0.5)
-                response = ser.readline()
-                if not response:
-                    response = ser.read(ser.in_waiting or 0)
-
-                if response:
-                    print(f"\n  {desc} + {cmd!r}:")
-                    print(f"    Raw: {response!r}")
-                    print(f"    Decoded: '{response.decode('ascii', errors='replace').strip()}'")
-                    print(f"    SUCCESS!")
-                    ser.close()
-                    return True
-            print(f"  {desc}: no response")
-        except Exception as e:
-            print(f"  {desc}: ERROR - {e}")
-        finally:
-            if ser.is_open:
-                ser.close()
-
-    return False
-
-
-def test_raw_dump(port):
-    """Test 4: Open port and dump any raw bytes for 10 seconds."""
-    print("\n--- Test 4: Raw byte dump (10 seconds, 9600 8-N-1) ---")
-    print("  Try pressing PRINT button on the scale during this test!")
-
-    ser = open_port(port)
-    try:
-        ser.reset_input_buffer()
-        start = time.time()
-        all_data = b''
-        while time.time() - start < 10.0:
-            waiting = ser.in_waiting
-            if waiting > 0:
-                chunk = ser.read(waiting)
-                all_data += chunk
-                elapsed = time.time() - start
-                print(f"  [{elapsed:.1f}s] {chunk!r}")
-            time.sleep(0.1)
-
-        if all_data:
-            print(f"\n  Total bytes received: {len(all_data)}")
-            print(f"  Hex: {all_data.hex(' ')}")
-            print(f"  ASCII: '{all_data.decode('ascii', errors='replace')}'")
-            return True
-        else:
-            print("  No bytes received in 10 seconds.")
-            return False
-    except Exception as e:
-        print(f"  ERROR: {e}")
-        return False
-    finally:
-        ser.close()
+def parse_response(raw):
+    """Parse SBI response into weight value and unit."""
+    text = raw.decode('ascii', errors='replace').strip()
+    match = WEIGHT_RE.search(text)
+    if match:
+        value = float(match.group(1).replace(' ', ''))
+        unit = match.group(2)
+        return value, unit, text
+    return None, None, text
 
 
 def main():
     print("=" * 60)
-    print("Sartorius Cubis II Scale - Communication Test v2")
+    print("Sartorius Cubis II Scale - Confirmed Config Test")
+    print(f"  Port: {PORT} | Baud: {BAUD} | Format: 8-N-1")
     print("=" * 60)
 
-    # Step 1: List ports
-    print("\n--- Detecting serial ports ---")
-    ports = list_serial_ports()
+    # List ports
+    list_serial_ports()
 
-    candidate_ports = []
-    for p in ports:
-        if 'ttyACM' in p.device or 'ttyUSB' in p.device or 'COM' in p.device:
-            candidate_ports.append(p.device)
-
-    if not candidate_ports:
-        print("\nNo candidate serial ports found.")
+    # Open connection
+    print(f"\nOpening {PORT}...")
+    try:
+        ser = open_scale()
+    except serial.SerialException as e:
+        print(f"ERROR: {e}")
         sys.exit(1)
 
-    port = candidate_ports[0]
-    print(f"\nUsing port: {port}")
+    print("Connected!\n")
 
-    # Test 1: Passive listen
-    if test_passive_listen(port):
-        print("\n>> Scale sends data without commands (continuous mode)")
+    # Test 1: Stable read (ESC P) — 5 consecutive reads
+    print("--- Test 1: ESC P (stable read) x5 ---")
+    for i in range(5):
+        ser.reset_input_buffer()
+        ser.write(CMD_STABLE_READ)
+        raw = ser.readline()
+        value, unit, text = parse_response(raw)
+        print(f"  Read {i+1}: raw={raw!r}  parsed={value} {unit}")
+        time.sleep(1.0)
 
-    # Test 2: SBI command variations
-    success, cmd, desc = test_sbi_commands(port)
-    if success:
-        print(f"\n>> Working command found: {desc}")
+    # Test 2: Immediate read (ESC S) — check if this also works
+    print("\n--- Test 2: ESC S (immediate read) x5 ---")
+    for i in range(5):
+        ser.reset_input_buffer()
+        ser.write(CMD_IMMEDIATE_READ)
+        raw = ser.readline()
+        value, unit, text = parse_response(raw)
+        if raw:
+            print(f"  Read {i+1}: raw={raw!r}  parsed={value} {unit}")
+        else:
+            print(f"  Read {i+1}: No response (ESC S not supported)")
+            if i == 0:
+                print("  Skipping remaining ESC S tests.")
+                break
+        time.sleep(1.0)
 
-    # Test 3: Different serial configs
-    if not success:
-        if test_serial_configs(port):
-            print("\n>> Found working serial configuration!")
+    # Test 3: Place something on the scale
+    print("\n--- Test 3: Live monitoring for 15 seconds ---")
+    print("  Place/remove objects on the scale to see value changes!")
+    start = time.time()
+    while time.time() - start < 15.0:
+        ser.reset_input_buffer()
+        ser.write(CMD_STABLE_READ)
+        raw = ser.readline()
+        value, unit, text = parse_response(raw)
+        elapsed = time.time() - start
+        if value is not None:
+            print(f"  [{elapsed:5.1f}s] {value:>10} {unit}")
+        else:
+            print(f"  [{elapsed:5.1f}s] (no response or parse error: '{text}')")
+        time.sleep(1.0)
 
-    # Test 4: Raw dump (last resort - asks user to press PRINT on scale)
-    if not success:
-        test_raw_dump(port)
-
+    ser.close()
     print("\n" + "=" * 60)
-    print("DONE. Share the output above so we can determine next steps.")
+    print("DONE. Share the output above.")
     print("=" * 60)
 
 

--- a/tests/test_scale_connection.py
+++ b/tests/test_scale_connection.py
@@ -7,7 +7,6 @@ Run this on the Raspberry Pi with the scale connected via USB:
 Prerequisites:
     - pip install pyserial
     - User must be in 'dialout' group: sudo usermod -a -G dialout $USER
-    - Scale touchscreen: Menu > Communication > USB > Protocol = SBI
 """
 
 import serial
@@ -28,57 +27,175 @@ def list_serial_ports():
     return ports
 
 
-def try_read_weight(port, baudrate, bytesize, parity, stopbits):
-    """Attempt to read weight from the scale with given serial parameters."""
-    params_str = f"{baudrate} baud, {bytesize} data bits, parity={parity}, {stopbits} stop bits"
-    print(f"\nTrying: {port} @ {params_str}")
+def open_port(port, baudrate=9600, bytesize=serial.EIGHTBITS,
+              parity=serial.PARITY_NONE, stopbits=serial.STOPBITS_ONE):
+    """Open serial port with given parameters."""
+    return serial.Serial(
+        port=port,
+        baudrate=baudrate,
+        bytesize=bytesize,
+        parity=parity,
+        stopbits=stopbits,
+        timeout=3.0
+    )
 
-    try:
-        ser = serial.Serial(
-            port=port,
-            baudrate=baudrate,
-            bytesize=bytesize,
-            parity=parity,
-            stopbits=stopbits,
-            timeout=2.0
-        )
-    except serial.SerialException as e:
-        print(f"  ERROR opening port: {e}")
-        return False
 
+def test_passive_listen(port):
+    """Test 1: Just listen for any data the scale sends without commands."""
+    print("\n--- Test 1: Passive listen (no commands sent) ---")
+    print("  Listening for 5 seconds for any data the scale sends...")
+
+    ser = open_port(port)
     try:
-        # Flush any stale data
         ser.reset_input_buffer()
-        time.sleep(0.1)
+        start = time.time()
+        data = b''
+        while time.time() - start < 5.0:
+            chunk = ser.read(ser.in_waiting or 1)
+            if chunk:
+                data += chunk
+                print(f"  Received: {chunk!r}")
+        if not data:
+            print("  No data received passively.")
+        else:
+            print(f"  Total received: {data!r}")
+            print(f"  Decoded: '{data.decode('ascii', errors='replace')}'")
+        return bool(data)
+    except Exception as e:
+        print(f"  ERROR: {e}")
+        return False
+    finally:
+        ser.close()
 
-        # Send SBI immediate read command (ESC S)
-        cmd = b'\x1bS\r\n'
-        print(f"  Sending: {cmd!r}")
-        ser.write(cmd)
 
-        # Read response
-        response_raw = ser.readline()
-        print(f"  Raw bytes:   {response_raw!r}")
-        print(f"  Decoded:     '{response_raw.decode('ascii', errors='replace').strip()}'")
+def test_sbi_commands(port):
+    """Test 2: Try SBI commands with different formats."""
+    print("\n--- Test 2: SBI command variations ---")
 
-        if not response_raw:
-            print("  No response received (timeout).")
-            # Try stable read command as fallback
-            print("  Retrying with ESC P (stable read)...")
-            ser.write(b'\x1bP\r\n')
-            response_raw = ser.readline()
-            print(f"  Raw bytes:   {response_raw!r}")
-            print(f"  Decoded:     '{response_raw.decode('ascii', errors='replace').strip()}'")
+    commands = [
+        (b'\x1bS\r\n', "ESC S CR LF (standard SBI immediate)"),
+        (b'\x1bP\r\n', "ESC P CR LF (standard SBI print/stable)"),
+        (b'\x1bS\r',   "ESC S CR (no LF)"),
+        (b'\x1bP\r',   "ESC P CR (no LF)"),
+        (b'S\r\n',     "S CR LF (no ESC prefix)"),
+        (b'P\r\n',     "P CR LF (no ESC prefix)"),
+        (b'\x1bQ\r\n', "ESC Q CR LF (query)"),
+        (b'W\r\n',     "W CR LF (weigh command)"),
+        (b'\x1b\x70\r\n', "ESC p (lowercase) CR LF"),
+    ]
 
-        if response_raw:
-            print("  SUCCESS - got a response!")
+    ser = open_port(port)
+    try:
+        for cmd, desc in commands:
+            ser.reset_input_buffer()
+            time.sleep(0.2)
+            print(f"\n  Sending {desc}: {cmd!r}")
+            ser.write(cmd)
+            time.sleep(0.5)
+
+            # Try readline first
+            response = ser.readline()
+            if not response:
+                # Also try reading raw bytes
+                response = ser.read(ser.in_waiting or 0)
+
+            if response:
+                print(f"  Raw bytes: {response!r}")
+                print(f"  Decoded:   '{response.decode('ascii', errors='replace').strip()}'")
+                print(f"  SUCCESS with: {desc}")
+                return True, cmd, desc
+            else:
+                print(f"  No response.")
+
+        return False, None, None
+    except Exception as e:
+        print(f"  ERROR: {e}")
+        return False, None, None
+    finally:
+        ser.close()
+
+
+def test_serial_configs(port):
+    """Test 3: Try different serial configurations with SBI commands."""
+    print("\n--- Test 3: Different serial configurations ---")
+
+    configs = [
+        (9600,  serial.EIGHTBITS, serial.PARITY_NONE, serial.STOPBITS_ONE, "9600 8-N-1"),
+        (9600,  serial.SEVENBITS, serial.PARITY_ODD,  serial.STOPBITS_ONE, "9600 7-O-1"),
+        (9600,  serial.SEVENBITS, serial.PARITY_EVEN, serial.STOPBITS_ONE, "9600 7-E-1"),
+        (19200, serial.EIGHTBITS, serial.PARITY_NONE, serial.STOPBITS_ONE, "19200 8-N-1"),
+        (19200, serial.SEVENBITS, serial.PARITY_ODD,  serial.STOPBITS_ONE, "19200 7-O-1"),
+        (115200, serial.EIGHTBITS, serial.PARITY_NONE, serial.STOPBITS_ONE, "115200 8-N-1"),
+    ]
+
+    commands = [b'\x1bS\r\n', b'\x1bP\r\n']
+
+    for baud, bits, parity, stop, desc in configs:
+        try:
+            ser = serial.Serial(
+                port=port, baudrate=baud, bytesize=bits,
+                parity=parity, stopbits=stop, timeout=2.0
+            )
+        except serial.SerialException as e:
+            print(f"\n  {desc}: ERROR opening - {e}")
+            continue
+
+        try:
+            for cmd in commands:
+                ser.reset_input_buffer()
+                time.sleep(0.1)
+                ser.write(cmd)
+                time.sleep(0.5)
+                response = ser.readline()
+                if not response:
+                    response = ser.read(ser.in_waiting or 0)
+
+                if response:
+                    print(f"\n  {desc} + {cmd!r}:")
+                    print(f"    Raw: {response!r}")
+                    print(f"    Decoded: '{response.decode('ascii', errors='replace').strip()}'")
+                    print(f"    SUCCESS!")
+                    ser.close()
+                    return True
+            print(f"  {desc}: no response")
+        except Exception as e:
+            print(f"  {desc}: ERROR - {e}")
+        finally:
+            if ser.is_open:
+                ser.close()
+
+    return False
+
+
+def test_raw_dump(port):
+    """Test 4: Open port and dump any raw bytes for 10 seconds."""
+    print("\n--- Test 4: Raw byte dump (10 seconds, 9600 8-N-1) ---")
+    print("  Try pressing PRINT button on the scale during this test!")
+
+    ser = open_port(port)
+    try:
+        ser.reset_input_buffer()
+        start = time.time()
+        all_data = b''
+        while time.time() - start < 10.0:
+            waiting = ser.in_waiting
+            if waiting > 0:
+                chunk = ser.read(waiting)
+                all_data += chunk
+                elapsed = time.time() - start
+                print(f"  [{elapsed:.1f}s] {chunk!r}")
+            time.sleep(0.1)
+
+        if all_data:
+            print(f"\n  Total bytes received: {len(all_data)}")
+            print(f"  Hex: {all_data.hex(' ')}")
+            print(f"  ASCII: '{all_data.decode('ascii', errors='replace')}'")
             return True
         else:
-            print("  No response.")
+            print("  No bytes received in 10 seconds.")
             return False
-
     except Exception as e:
-        print(f"  ERROR during communication: {e}")
+        print(f"  ERROR: {e}")
         return False
     finally:
         ser.close()
@@ -86,99 +203,46 @@ def try_read_weight(port, baudrate, bytesize, parity, stopbits):
 
 def main():
     print("=" * 60)
-    print("Sartorius Cubis II Scale - Communication Test")
+    print("Sartorius Cubis II Scale - Communication Test v2")
     print("=" * 60)
 
     # Step 1: List ports
-    print("\n--- Step 1: Detecting serial ports ---")
+    print("\n--- Detecting serial ports ---")
     ports = list_serial_ports()
 
-    # Find likely scale port (ttyACM or ttyUSB devices)
     candidate_ports = []
     for p in ports:
-        if 'ttyACM' in p.device or 'ttyUSB' in p.device:
+        if 'ttyACM' in p.device or 'ttyUSB' in p.device or 'COM' in p.device:
             candidate_ports.append(p.device)
 
     if not candidate_ports:
-        # On Windows, look for COM ports
-        for p in ports:
-            if 'COM' in p.device:
-                candidate_ports.append(p.device)
-
-    if not candidate_ports:
         print("\nNo candidate serial ports found.")
-        print("Check that the scale is connected via USB and powered on.")
         sys.exit(1)
 
-    print(f"\nCandidate ports: {candidate_ports}")
+    port = candidate_ports[0]
+    print(f"\nUsing port: {port}")
 
-    # Step 2: Try each port with different serial configurations
-    print("\n--- Step 2: Testing communication ---")
+    # Test 1: Passive listen
+    if test_passive_listen(port):
+        print("\n>> Scale sends data without commands (continuous mode)")
 
-    configs = [
-        # Default SBI: 9600, 7-O-1
-        (9600, serial.SEVENBITS, serial.PARITY_ODD, serial.STOPBITS_ONE),
-        # Alternative: 19200, 7-O-1
-        (19200, serial.SEVENBITS, serial.PARITY_ODD, serial.STOPBITS_ONE),
-        # Alternative: 9600, 8-N-1
-        (9600, serial.EIGHTBITS, serial.PARITY_NONE, serial.STOPBITS_ONE),
-        # Alternative: 19200, 8-N-1
-        (19200, serial.EIGHTBITS, serial.PARITY_NONE, serial.STOPBITS_ONE),
-    ]
+    # Test 2: SBI command variations
+    success, cmd, desc = test_sbi_commands(port)
+    if success:
+        print(f"\n>> Working command found: {desc}")
 
-    success = False
-    for port in candidate_ports:
-        for baudrate, bytesize, parity, stopbits in configs:
-            if try_read_weight(port, baudrate, bytesize, parity, stopbits):
-                success = True
-                print(f"\n{'=' * 60}")
-                print(f"WORKING CONFIG FOUND!")
-                print(f"  Port:      {port}")
-                print(f"  Baud rate: {baudrate}")
-                print(f"  Data bits: {bytesize}")
-                print(f"  Parity:    {parity}")
-                print(f"  Stop bits: {stopbits}")
-                print(f"{'=' * 60}")
-
-                # Do a few more reads to confirm
-                print("\nPerforming 5 consecutive reads (1 second apart)...")
-                try:
-                    ser = serial.Serial(
-                        port=port,
-                        baudrate=baudrate,
-                        bytesize=bytesize,
-                        parity=parity,
-                        stopbits=stopbits,
-                        timeout=2.0
-                    )
-                    for i in range(5):
-                        ser.reset_input_buffer()
-                        ser.write(b'\x1bS\r\n')
-                        resp = ser.readline()
-                        decoded = resp.decode('ascii', errors='replace').strip()
-                        print(f"  Read {i+1}: '{decoded}'")
-                        time.sleep(1.0)
-                    ser.close()
-                except Exception as e:
-                    print(f"  Error during consecutive reads: {e}")
-
-                return
-        if not success:
-            print(f"\nNo working config found for {port}")
-
+    # Test 3: Different serial configs
     if not success:
-        print("\n" + "=" * 60)
-        print("FAILED: Could not communicate with the scale.")
-        print("Troubleshooting:")
-        print("  1. Check scale is powered on and USB cable is connected")
-        print("  2. On the scale touchscreen: Menu > Communication > USB")
-        print("     - Protocol should be set to 'SBI'")
-        print("  3. Verify user is in dialout group:")
-        print("     sudo usermod -a -G dialout $USER")
-        print("     (then log out and back in)")
-        print("  4. Check dmesg for USB device detection:")
-        print("     dmesg | tail -20")
-        print("=" * 60)
+        if test_serial_configs(port):
+            print("\n>> Found working serial configuration!")
+
+    # Test 4: Raw dump (last resort - asks user to press PRINT on scale)
+    if not success:
+        test_raw_dump(port)
+
+    print("\n" + "=" * 60)
+    print("DONE. Share the output above so we can determine next steps.")
+    print("=" * 60)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
### Summary                                                                                                                                                                                                             
  - I ntegrate Sartorius Cubis II MCA5201S-2S00-0 precision scale via USB serial (SBI protocol) — weight is displayed live on the HMI and recorded in Excel exports                                               
  - Fix torque sensor showing non-zero value at idle by subtracting 0.1V load cell baseline offset                                                                                                               
  - Fix RPM reading noise (was reading ~15 RPM high with spikes) using median filter and spike clamping

### Changes

####  Scale Integration

  - New: `hmi/sensors/scale.py` — Scale sensor class with background polling thread, auto-detect/reconnect, SBI protocol communication (19200 baud, 8-N-1, ESC P command)
  - `hmi/HMIApp.py` — Instantiate Scale, display weight live (updates even when motor is stopped), record weight data each second during runs
  - `hmi/hmi.kv` — Added "Weight (g)" display row in the right panel
  - `hmi/excel.py` — Added Weight column (J) to Excel export
  - `requirements.txt` — Added pyserial==3.5

####  Sensor Fixes
  - `hmi/sensors/stepper_motor.py` — Torque: subtract 0.1V ADC offset (load cell zero output). RPM: clamp noise spikes >150% of target RPM
  - `hmi/HMIApp.py` — RPM: increased averaging window from 3 to 5 samples, switched from mean to median filter

####  Documentation & Tests

  - New: `docs/scale-integration-guide.md` — Operator guide covering hardware setup, SBI protocol, serial parameters, troubleshooting
  - New: `tests/test_scale_connection.py` — Standalone serial communication diagnostic script
  - New: `tests/test_scale_class.py` — Scale class verification script

####  Test plan

  - Scale reads weight correctly via USB serial (verified with 0g, 74g, 256g, 438g, 620g readings)
  - Scale auto-reconnects when USB is unplugged/replugged
  - Weight displays live on HMI without pressing START
  - Weight recorded in Excel export during motor runs
  - App starts normally with scale disconnected (shows 0.0)
  - Torque shows 0.0 at idle (no phantom readings)
  - RPM spikes eliminated, readings stable at setpoint